### PR TITLE
Update Imap::Backup Account "def root_for"..

### DIFF
--- a/lib/imap/backup/account/connection.rb
+++ b/lib/imap/backup/account/connection.rb
@@ -96,7 +96,7 @@ module Imap::Backup
       when /@fastmail\.fm/
         'INBOX'
       else
-        '/'
+        ''
       end
     end
 


### PR DESCRIPTION
used in "def folders"

based on
http://ruby-doc.org/stdlib-2.0.0/libdoc/net/imap/rdoc/Net/IMAP.html#list-method
its possible to leave the 'refname' empty, which uses the 'mailbox' directly.

this works for zimbra imap server
