### PR TITLE
Set account folder permissions on creation.

### DIFF
--- a/lib/imap/backup/account/connection.rb
+++ b/lib/imap/backup/account/connection.rb
@@ -13,6 +13,7 @@ module Imap::Backup
       @backup_folders = options[:folders]
       @server = options[:server]
       @folders = nil
+      create_account_folder
     end
 
     def folders
@@ -66,6 +67,14 @@ module Imap::Backup
         serializer = Serializer::Mbox.new(local_path, folder_info[:name])
         yield folder, serializer
       end
+    end
+
+    def create_account_folder
+      Utils.make_folder(
+        Configuration::Store::CONFIGURATION_DIRECTORY,
+        File.basename(local_path),
+        Serializer::DIRECTORY_PERMISSIONS
+      )
     end
 
     def password

--- a/spec/unit/account/connection_spec.rb
+++ b/spec/unit/account/connection_spec.rb
@@ -26,6 +26,7 @@ describe Imap::Backup::Account::Connection do
 
   before do
     allow(Net::IMAP).to receive(:new).and_return(imap)
+    allow(Imap::Backup::Utils).to receive(:make_folder)
   end
 
   subject { described_class.new(options) }
@@ -49,6 +50,11 @@ describe Imap::Backup::Account::Connection do
       it "expects #{attr}" do
         expect(subject.send(attr)).to eq(expected)
       end
+    end
+
+    it 'creates the path' do
+      subject.username
+      expect(Imap::Backup::Utils).to have_received(:make_folder)
     end
   end
 


### PR DESCRIPTION
The fix for issue #29 is incomplete, as .imap-backup/<account name> is still set incorrectly (although .imap-backup and .imap-backup/<account name>/<folder> are still correct). This can cause an execution failure on a second execution depending on the umask set by the user environment.

This patch explicitly creates the account folder with the correct permissions during the connection setup stage.