### PR TITLE
Add option to print version

### DIFF
--- a/bin/imap-backup
+++ b/bin/imap-backup
@@ -34,6 +34,11 @@ opts = OptionParser.new do |opts|
     puts opts
     exit
   end
+
+  opts.on_tail("--version", "Show version" ) do
+    puts Imap::Backup::VERSION
+    exit
+  end
 end
 opts.parse!
 


### PR DESCRIPTION
Adds long option `--version` to print version number.

I was trying to determine if I had the most up-to-date version of imap-backup installed and would have found this option helpful.

Usage information now looks like this:
```
$ imap-backup -h
Usage: imap-backup [options] COMMAND

Commands:
	setup                Create/edit the configuration file
	backup               Do the backup (default)
	folders              List folders for all (or selected) accounts
	status               List count of non backed-up emails per folder
	help                 Show usage

Common options:
    -a ACCOUNT1[,ACCOUNT2,...],      only these accounts
        --accounts
    -h, --help                       Show usage
        --version                    Show version
```

The version number is printed like this:
```
imap-backup --version
1.2.1
```