### PR TITLE
Add backtrace to 'failed to save message' log

### DIFF
--- a/lib/imap/backup/serializer/mbox.rb
+++ b/lib/imap/backup/serializer/mbox.rb
@@ -46,7 +46,7 @@ module Imap::Backup
         mbox.write mboxrd_message.to_s
         imap.write uid + "\n"
       rescue => e
-        Imap::Backup.logger.warn "[#{folder}] failed to save message #{uid}:\n#{body}. #{e}"
+        Imap::Backup.logger.warn "[#{folder}] failed to save message #{uid}:\n#{body}. #{e}:\n#{e.backtrace.join("\n")}"
       ensure
         mbox.close if mbox
         imap.close if imap


### PR DESCRIPTION
I think this would be useful to include in future releases. Specifically, it will help to diagnose errors such as those reported in #40 and #42.