### PR TITLE
Update Gemfile `rubocop-rails`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,4 @@ AllCops:
     - "bin/stubs/*"
   DisplayCopNames:
     Enabled: true
+        require: rubocop-rails

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
-
+gem 'rubocop-rails'
 gemspec


### PR DESCRIPTION
Rails cops will be removed from RuboCop 0.72, i update the Gemfile and .rubocop.yml for use `rubocop-rails` gem.