### PR TITLE
get list of gem files from file system and .gitignore

### DIFF
--- a/imap-backup.gemspec
+++ b/imap-backup.gemspec
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift(File.expand_path("lib", __dir__))
 require "imap/backup/version"
+require "rake/file_list"
 
 Gem::Specification.new do |gem|
   gem.name          = "imap-backup"
@@ -8,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.authors       = ["Joe Yates"]
   gem.email         = ["joe.g.yates@gmail.com"]
   gem.homepage      = "https://github.com/joeyates/imap-backup"
+  gem.licenses      = ["MIT"]
 
   gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/imap-backup.gemspec
+++ b/imap-backup.gemspec
@@ -11,7 +11,15 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/joeyates/imap-backup"
   gem.licenses      = ["MIT"]
 
-  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  # Build list of files manually, see also
+  # https://github.com/rubygems/rubygems/blob/master/bundler/bundler.gemspec#L37
+  gem.files         = %w[bin/imap-backup]
+  gem.files         += Dir.glob("docs/*{.png,.md}")
+  gem.files         += Dir.glob("lib/**/*.rb")
+  gem.files         += Dir.glob("spec/**/*{.rb,.yml}")
+  gem.files         += %w[imap-backup.gemspec]
+  gem.files         += %w[LICENSE README.md]
+
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Currently, it is not possible to build a gem from the GitHub archives for each tag. This PR should fix that.