### PR TITLE
Guide on e-mail server migration while keeping address

### DIFF
--- a/docs/commands/migrate.md
+++ b/docs/commands/migrate.md
@@ -1,7 +1,7 @@
 # Migrate
 
 ```sh
-imap-backup migrate SOURCE_EMAIL DESTINATION_EMAIL
+imap-backup migrate SOURCE_EMAIL DESTINATION_EMAIL [OPTIONS]
 ```
 
 This command copies backed up emails for one account (the "source")
@@ -9,13 +9,19 @@ to another account (the "destination").
 
 # Options
 
-* `reset` - delete all messages from destination folders before uploading,
-* `source-delimiter` - the separator between the elements of folders names on the source server, defaults to `/`,
-* `source-prefix` - optionally, a prefix element to remove from the name of source folders,
-* `destination-delimiter` - the separator between the elements of folders names on the destination server, defaults to `/`,
-* `destination-prefix` - optionally, a prefix element to add before names on the destination server.
+* `--reset` - delete all messages from destination folders before uploading,
+* `--source-delimiter` - the separator between the elements of folders names on the source server, defaults to `/`,
+* `--source-prefix` - optionally, a prefix element to remove from the name of source folders,
+* `--destination-delimiter` - the separator between the elements of folders names on the destination server, defaults to `/`,
+* `--destination-prefix` - optionally, a prefix element to add before names on the destination server.
 
-# Delimiters and Prefixes
+# FAQ
+
+## How to use delimiters and prefixes?
 
 For details of the delimiter and prefix options,
-see [the note about delimiters and prefixes](../delimiters-and-prefixes.md).
+see [the note about delimiters and prefixes](/docs/delimiters-and-prefixes.md).
+
+## How to migrate to a new server while keeping the same e-mail address?
+
+See [this note on the topic](/docs/migrate-server-keep-address.md).

--- a/docs/commands/restore.md
+++ b/docs/commands/restore.md
@@ -1,5 +1,9 @@
 # Restore
 
+```sh
+imap-backup restore EMAIL_ADDRESS
+```
+
 All missing messages are pushed to the IMAP server.
 Existing messages are left unchanged.
 
@@ -8,12 +12,12 @@ extension to IMAP4.
 
 # FAQ
 
-# How does restore work?
+## How does restore work?
 
 Backed-up emails are pushed to the IMAP server.
 If there are clashes, folders are renamed.
 
-# What are all these 'INBOX.12345' files?
+## What are all these 'INBOX.12345' files?
 
 If, when the backup is launched, the IMAP server contains a folder with
 the same name, but different history to the local backup, the local
@@ -24,13 +28,13 @@ before it is restored.
 
 In this way, old and new emails are kept separate.
 
-# Will my email get overwritten?
+## Will my email get overwritten?
 
 No.
 
 Emails are identified by folder and a specific email id. Any email that
 is already on the server is skipped.
 
-## How do I restore to a different service?
+## How to restore e-mails to a new service while keeping the same e-mail address?
 
-It is best to use the `migrate` command in this case.
+If you are switching to a new e-mail provider, but want to keep your existing e-mail address, it is best to use the [`migrate`](/docs/commands/migrate.md) command instead of `restore`. See [this guide on the topic](/docs/migrate-server-keep-address.md).

--- a/docs/migrate-server-keep-address.md
+++ b/docs/migrate-server-keep-address.md
@@ -1,0 +1,29 @@
+# Migrate to a new e-mail server while keeping your existing address
+
+While switching e-mail provider (from provider `A` to `B`), you might want to keep the same address (`mymail@domain.com`), and restrieve all your existing e-mails on your new server `B`. `imap-backup` can do that too!
+
+1. Backup your e-mails: use [`imap-backup setup`](/docs/commands/setup.md) to setup connection to your old provider `A`, then launch [`imap-backup backup`](/docs/commands/backup.md). 
+1. Actually switch your e-mail service provider (update your DNS MX and all that...).
+1. It is best to use [`imap-backup migrate`](/docs/commands/migrate.md) and not [`imap-backup restore`](/docs/commands/restore.md) here, but both the source and the destination have the same address... You need to manually rename your old account first:
+
+	1. Modify your configuration file manually (i.e. not via `imap-backup setup`) and rename your account to `mymail-old@domain.com`:
+
+		```diff
+		"accounts": [
+		{
+		-	"username": "mymail@domain.com",
+		+	"username": "mymail-old@domain.com",
+			"password": "...",
+		-	"local_path": "/some/path/.imap-backup/mymail_domain.com",
+		+	"local_path": "/some/path/.imap-backup/mymail-old_domain.com",
+			"folders": [...],
+			"server": "..."
+		}
+		```
+
+	1. Rename the backup directory from `mymail_domain.com` to `mymail-old_domain.com`.
+
+1. Set up a new account giving access to the new provider `B` using `imap-backup setup`.
+1. Now you can use `imap-backup migrate`, optionnally adapting [delimiters and prefixes configuration](/docs/delimiters-and-prefixes.md) if need be:
+
+		imap-backup migrate mymail-old@domain.com mymail@domain.com [options]


### PR DESCRIPTION
Also improves `migrate` and `restore` documentations.

TODO : Would be nice to know where to find the `imap-backup`'s root directory on different OSes (where the configuration file and the backups are located).