### PR TITLE
Don't keep checking if migration is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 9.3.2 - 2023-06-04
+
+## Changed
+
+* Improved performance of large backups by avoiding unnecessary serialized
+  IMAP data migration and validation checks.
+
 ## 9.3.1 - 2023-05-12
 
 ## Changed

--- a/lib/imap/backup/serializer.rb
+++ b/lib/imap/backup/serializer.rb
@@ -30,14 +30,20 @@ module Imap::Backup
     def initialize(path, folder)
       @path = path
       @folder = folder
+      @validated = nil
     end
 
     # Returns true if there are existing, valid files
     # false otherwise (in which case any existing files are deleted)
     def validate!
+      return if @validated
+
       optionally_migrate2to3
 
-      return true if imap.valid? && mbox.valid?
+      if imap.valid? && mbox.valid?
+        @validated = true
+        return true
+      end
 
       delete
 

--- a/lib/imap/backup/version.rb
+++ b/lib/imap/backup/version.rb
@@ -3,7 +3,7 @@ module Imap; end
 module Imap::Backup
   MAJOR    = 9
   MINOR    = 3
-  REVISION = 1
+  REVISION = 2
   PRE      = nil
   VERSION  = [MAJOR, MINOR, REVISION, PRE].compact.map(&:to_s).join(".")
 end


### PR DESCRIPTION
This has serious performance penalties when the imap file is large as the check is being run for each message imported. With a 20MB imap file (approximately 300,000) emails, it takes about 0.5 seconds to check the migration status on each message import.

Instead, we remember that we have checked migratability and skip the check on subsequent calls to `validate!`.