### PR TITLE
Add multi-step dockerfile and example compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,8 @@
 /jgy-*
 /.#.*
 /.emacs.*
+/.github
+/docs
+/container
+/tmp
+/Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+ARG RUBY_VERSION=3.2
+FROM ruby:$RUBY_VERSION-alpine as builder
+
+WORKDIR /app
+COPY . .
+
+# install dependencies
+RUN apk add libffi-dev alpine-sdk
+RUN gem install bundler --version=2.3.22
+RUN bundle install
+
+FROM ruby:$RUBY_VERSION-alpine as final
+ENV HOME=/config
+WORKDIR /app
+COPY . .
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+
+ENTRYPOINT ["bundle", "exec", "imap-backup"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,10 @@
-# This file adapted from github.com/antespi/docker-imap-devel
 version: "3"
 
 services:
-  imap:
-    image: antespi/docker-imap-devel:latest
-    container_name: imap
-    ports:
-    - "8993:993"
-    environment:
-    - MAILNAME=example.com
-    - MAIL_ADDRESS=address@example.com
-    - MAIL_PASS=pass
-  other-imap:
-    image: antespi/docker-imap-devel:latest
-    container_name: other-imap
-    ports:
-    - "9993:993"
-    environment:
-    - MAILNAME=other.org
-    - MAIL_ADDRESS=email@other.org
-    - MAIL_PASS=pass
+  imap-backup:
+    container_name: imap-backup
+    build:
+      context: .
+    volumes:
+      - ./data:/data
+      - ./config:/config


### PR DESCRIPTION
This image differs from the debian build in that it is not designed to be run interactively but to run automatically. automatic cron runs would not be difficult but not sure if that would be desirable.
bash is not present and the entrypoint is passed in, eliminating the need for binstubs

I'm not sure how you would like documentation for running to be handled, so I will await your guidance. 

alpine linux was chosen because of it's [much smaller size](https://hub.docker.com/layers/library/ruby/alpine/images/sha256-8e90a920a0c3074cd8c2f6cfab9422013e280af9ef1338e969254cdf222eb2c1?context=explore) (37MB) compared to [bullseye](https://hub.docker.com/layers/library/ruby/bullseye/images/sha256-00fccb6dc5eb4e64fef533d8118e6ca46dfe487ef900b356e0001f1a7136351b?context=explore) (340MB) but most importantly to this project, `bash` is dropped in favor of `ash`