### PR TITLE
SSL: Migrate deprecated `ssl_version` to `min_version` to support TLSv1.3 connections out of the box

### DIFF
--- a/lib/imap/backup/email/provider/base.rb
+++ b/lib/imap/backup/email/provider/base.rb
@@ -9,7 +9,7 @@ module Imap::Backup
     # @return [Hash] defaults for the Net::IMAP connection
     def options
       # rubocop:disable Naming/VariableNumber
-      {port: 993, ssl: {ssl_version: :TLSv1_2}}
+      {port: 993, ssl: {min_version: OpenSSL::SSL::TLS1_2_VERSION}}
       # rubocop:enable Naming/VariableNumber
     end
 

--- a/spec/unit/email/provider/base_spec.rb
+++ b/spec/unit/email/provider/base_spec.rb
@@ -9,7 +9,7 @@ module Imap::Backup
 
       it "forces TLSv1_2" do
         # rubocop:disable Naming/VariableNumber
-        expect(subject.options[:ssl][:ssl_version]).to eq(:TLSv1_2)
+        expect(subject.options[:ssl][:min_version]).to eq(OpenSSL::SSL::TLS1_2_VERSION)
         # rubocop:enable Naming/VariableNumber
       end
     end


### PR DESCRIPTION
I'm running an own Dovecot IMAP server and for sake of security and to repel the bruteforce attacks on any publicy available host (and I can assure you, there are plenty of them), I only allow TLSv1.3 and elliptic cryptographics. 

With this patch I got this also working for imap-backup. I'hope the intention is untouched and the constant reference notation as well as the unit test still correct.


The attribute `ssl_version` is deprecated in Ruby, and with this option set it's hard to enable TLSv1.3 connections.

Migrating this to `min_version` should keep the intention but enable TLSv1.3 connections.

https://docs.ruby-lang.org/en/master/OpenSSL/SSL/SSLContext.html#method-i-ssl_version-3D