### PR TITLE
write the metadata file once after refreshing all flags

### DIFF
--- a/lib/imap/backup/flag_refresher.rb
+++ b/lib/imap/backup/flag_refresher.rb
@@ -16,8 +16,10 @@ module Imap::Backup
     def run
       uids = serializer.uids.clone
 
-      uids.each_slice(CHUNK_SIZE) do |block|
-        refresh_block block
+      serializer.transaction do
+        uids.each_slice(CHUNK_SIZE) do |block|
+          refresh_block block
+        end
       end
     end
 

--- a/lib/imap/backup/serializer.rb
+++ b/lib/imap/backup/serializer.rb
@@ -84,7 +84,11 @@ module Imap::Backup
     #
     # @return [void]
     def transaction(&block)
-      block.call
+      mbox.transaction do
+        imap.transaction do
+          block.call
+        end
+      end
     end
 
     # Checks that the metadata files are valid, migrates the metadata file


### PR DESCRIPTION
The DelayedMetadataSerializer works excellently during message download, but the FlagRefresher uses Serializer without any batching or transaction, causing the metadata file to be written for each message. For my backup of ~50k messages, this produces a rather large amount of disk writes (~20GB for INBOX alone).

I've updated the FlagRefresher to do the refresh work inside a Serializer transaction, which I've implemented to do transactions on both mbox and imap metadata.

In my testing this makes a incremental mirror backup take < 1 min with almost no disk writes.