### PR TITLE
Add 'env' parameter for the 'backup' command

### DIFF
--- a/docs/commands/backup.md
+++ b/docs/commands/backup.md
@@ -21,6 +21,21 @@ As an alternative, if you only want to backup a single account,
 you can pass all the necessary parameters directly to the `single backup` command
 (see the [`single backup`](./single-backup.md) docs).
 
+# Environment variables
+
+For passwords only, it is possible to use an environment variable adding the
+`--env` (or `-e`) parameter. In such case, the value entered as password with
+`imap-backup setup`, or in the configuration file, must be a valid environment
+variable name preceded with a dollar sign, for example `$PASSWORD`.
+
+> [!NOTE]
+> The regular expression for valid names is `/^\$([A-Za-z_][A-Za-z0-9_]*)$/`.
+
+> [!NOTE]
+> If the environment variable is not set you will get a password prompt when
+> running `imap-backup backup --env`. **Your password will not be stored**,
+> it is entered temporarily and never written to disk.
+
 # Serialized Format
 
 Emails are stored on disk in [Mbox files](../files/mboxrd.md), one for each folder,

--- a/docs/commands/setup.md
+++ b/docs/commands/setup.md
@@ -23,6 +23,26 @@ In this case, it is up to you to create the directory for the configuration file
 
 # Account Setup
 
+## `modify password`
+
+Note that the password is held in plain text in the configuration file.
+
+You can avoid having your password held in plain text in the configuration file
+by providing an environment variable name preceded with a dollar sign, for
+example `$PASSWORD`.
+
+Then use the `backup` command with the `--env` (or `-e`) parameter:
+
+```sh
+imap-backup backup --env
+```
+
+> [!NOTE]
+> If the environment variable is not set – `$PASSWORD` in the above example –
+> you will get a password prompt when running `imap-backup backup --env`.
+> **Your password will not be stored**, it is entered temporarily and never
+> written to disk.
+
 ## `modify server`
 
 For GMail accounts, use `imap.gmail.com` as the 'server' setting.

--- a/docs/files/config.md
+++ b/docs/files/config.md
@@ -30,6 +30,40 @@ A typical configuration file looks like this:
 Note that email usernames and passwords are held in plain text
 in the configuration file.
 
+You can avoid having your password held in plain text in the configuration file
+by setting an environment variable and passing the `--env` (or `-e`) parameter
+to the `backup` command. Here is an example configuration file:
+
+```json
+{
+  "accounts": [
+    {
+      "username": "my.user@ikmail.com",
+      "password": "$PASSWORD",
+      "local_path": "/path/to/backup/root",
+      "folders": [
+        {"name": "Drafts"},
+        {"name": "Spam"},
+        {"name": "Trash"},
+      ],
+      "folder_blacklist": true,
+      "server": "imap.infomaniak.com",
+      "connection_options": {
+        "port": 993
+      },
+      "multi_fetch_size": 10
+    }
+  ],
+  "download_strategy": "delay_metadata"
+}
+```
+
+> [!NOTE]
+> If the environment variable is not set – `$PASSWORD` in the above example –
+> you will get a password prompt when running `imap-backup backup --env`.
+> **Your password will not be stored**, it is entered temporarily and never
+> written to disk.
+
 The directory ~/.imap-backup, the configuration file and all backup
 directories have their access permissions set to only allow access
 by your user. This is not done on Windows - see below.

--- a/lib/imap/backup/cli.rb
+++ b/lib/imap/backup/cli.rb
@@ -64,6 +64,7 @@ module Imap::Backup
     DESC
     accounts_option
     config_option
+    env_option
     quiet_option
     refresh_option
     verbose_option

--- a/lib/imap/backup/cli/backup.rb
+++ b/lib/imap/backup/cli/backup.rb
@@ -27,6 +27,7 @@ module Imap::Backup
         Logger.logger.debug "Loading configuration"
         config = load_config(**options)
         exit_code = nil
+        assign_env_vars(config, options)
         accounts = requested_accounts(config)
         # Filter to only include accounts available for backup
         accounts = accounts.select(&:available_for_backup?)

--- a/lib/imap/backup/cli/helpers.rb
+++ b/lib/imap/backup/cli/helpers.rb
@@ -1,3 +1,4 @@
+require "io/console"
 require "thor"
 
 require "imap/backup/cli/options"
@@ -37,6 +38,10 @@ module Imap::Backup
       To check what values you should use, check the output of the
       `imap-backup remote namespaces EMAIL` command.
     DESC
+
+    # @return [Regexp] regular expression matching an environment variable
+    #   starting with "$".
+    ENV_VAR_REGEX = /^\$([A-Za-z_][A-Za-z0-9_]*)$/
 
     # Processes command-line parameters
     # @return [Hash] the supplied command-line parameters with
@@ -93,6 +98,30 @@ module Imap::Backup
       else
         config.accounts
       end
+    end
+
+    # If the `env` option is provided, assign their values to the
+    # environment variables found in the application configuration for the
+    # `password` property.
+    # For variables present in the application configuration which are not
+    # set as environment variables, prompt the user for entering a password.
+    # @return [Configuration] the updated application configuration
+    def assign_env_vars(config, options)
+      return config unless options[:env]
+
+      config.accounts.each do |a|
+        env_var = a.password.match(ENV_VAR_REGEX)&.[](1)
+        next if env_var.nil?
+
+        if ENV.key?(env_var)
+          a.password = a.password.gsub(ENV_VAR_REGEX, ENV[env_var])
+        else
+          print "\nEnter your password: "
+          a.password = IO.console.noecho(&:gets)&.chomp
+        end
+      end
+
+      config
     end
   end
 end

--- a/lib/imap/backup/cli/options.rb
+++ b/lib/imap/backup/cli/options.rb
@@ -26,6 +26,13 @@ module Imap::Backup
         }
       },
       {
+        name: "env",
+        parameters: {
+          type: :string, aliases: ["-e"],
+          desc: "enable environment variables for passwords in the configuration file"
+        }
+      },
+      {
         name: "format",
         parameters: {
           type: :string, desc: "the output type, 'text' for plain text or 'json'", aliases: ["-f"]

--- a/spec/unit/cli/helpers_spec.rb
+++ b/spec/unit/cli/helpers_spec.rb
@@ -15,8 +15,8 @@ module Imap::Backup
     subject { WithHelpers.new(options) }
 
     let(:email) { "email@example.com" }
-    let(:first_account) { instance_double(Account, username: email) }
-    let(:second_account) { instance_double(Account, username: "foo") }
+    let(:first_account) { instance_double(Account, username: email, password: "foo") }
+    let(:second_account) { instance_double(Account, username: "foo", password: "bar") }
     let(:accounts) { [first_account, second_account] }
     let(:config) { instance_double(Configuration, accounts: accounts) }
     let(:options) { {} }
@@ -102,6 +102,57 @@ module Imap::Backup
 
         it "returns all configured accounts" do
           expect(subject.requested_accounts(config)).to eq(accounts)
+        end
+      end
+    end
+
+    describe ".env_vars" do
+      let(:env_account1) { instance_double(Account, password: "$FOO") }
+      let(:env_account2) { instance_double(Account, password: "$BAR") }
+      let(:env_accounts) { [env_account1, env_account2] }
+      let(:env_cfg) { instance_double(Configuration, accounts: env_accounts) }
+      let(:options) { {env: "env"} }
+      let(:console) { double("IO::Console") }
+
+      before do
+        allow(env_account1).to receive(:password=)
+        allow(ENV).to receive(:key?).with("FOO").and_return(true)
+        allow(ENV).to receive("[]").with("FOO").and_return("bar")
+
+        allow(env_account2).to receive(:password=)
+        allow(ENV).to receive(:key?).with("BAR").and_return(false)
+        allow(IO).to receive(:console).and_return(console)
+        allow(console).to receive(:noecho).and_yield(double("IO", gets: "pwd"))
+        allow($stdout).to receive(:write).and_return(nil)
+      end
+
+      it "replaces environment variables for password fields" do
+        subject.assign_env_vars(env_cfg, options)
+
+        expect(env_account1).to have_received(:password=).with("bar")
+      end
+
+      context "when the environment variable is not set" do
+        it "prompt the user to enter the password" do
+          subject.assign_env_vars(env_cfg, options)
+
+          expect($stdout).to have_received(:write).with("\nEnter your password: ")
+          expect(env_account2).to have_received(:password=).with("pwd")
+        end
+      end
+
+      context "when there is no environment variable in configuration" do
+        it "returns the configuration as is" do
+          expect(subject.assign_env_vars(config, options)).to eq(config)
+        end
+      end
+
+      context "when the `env` command option is not set" do
+        let(:options) { {} }
+
+        it "returns the configuration as is" do
+          expect(subject.assign_env_vars(config, options)).to eq(config)
+          expect(subject.assign_env_vars(env_cfg, options)).to eq(env_cfg)
         end
       end
     end


### PR DESCRIPTION
This commit addresses [#issue 167](https://github.com/joeyates/imap-backup/issues/167)

Passing `--env` to the `backup` commands enables the use of environment variables for passwords in the configuration file.

It allows users to not store their password in plain text in the configuration file.

Passwords in the configuration file which are valid environment variable names preceded by a dollar sign are replaced by the value of the corresponding environment variable.
For example: `"password" : "$PASSWORD"`

When the environment variable is not set, the user gets a password prompt.

When the password is not a valid environment variable name preceded by a dollar sign, the configuration is returned as is.