### PR TITLE
Fix backup of folders with escaped characters in their name

### DIFF
--- a/lib/imap/backup/account/folder_mapper.rb
+++ b/lib/imap/backup/account/folder_mapper.rb
@@ -2,6 +2,7 @@ require "thor"
 require "pathname"
 
 require "imap/backup/account/folder"
+require "imap/backup/naming"
 require "imap/backup/serializer"
 require "imap/backup/serializer/files/path"
 
@@ -112,11 +113,15 @@ module Imap::Backup
       imap_name = imap_pathname.relative_path_from(base).to_s
       dir = File.dirname(imap_name)
       stripped = File.basename(imap_name, ".imap")
-      if dir == "."
-        stripped
-      else
-        File.join(dir, stripped)
-      end
+      local_name =
+        if dir == "."
+          stripped
+        else
+          File.join(dir, stripped)
+        end
+      # Reverse the escaping applied when the backup was written so that the
+      # original folder name (including any reserved characters) is reproduced.
+      Naming.from_local_path(local_name)
     end
   end
 end

--- a/lib/imap/backup/account/serialized_folders.rb
+++ b/lib/imap/backup/account/serialized_folders.rb
@@ -1,6 +1,7 @@
 require "pathname"
 
 require "imap/backup/account/folder"
+require "imap/backup/naming"
 require "imap/backup/serializer"
 require "imap/backup/serializer/directory_maker"
 require "imap/backup/serializer/files/path"
@@ -27,7 +28,7 @@ module Imap::Backup
       return enum_for(:each) if !block
 
       glob.each do |path|
-        name = path.relative_path_from(base).to_s[0..-6]
+        name = folder_name(path)
         files_path = Serializer::Files::Path.new(
           base_path: account.local_path, folder_name: name
         )
@@ -44,7 +45,7 @@ module Imap::Backup
       return enum_for(:each_key) if !block
 
       glob.each do |path|
-        name = path.relative_path_from(base).to_s[0..-6]
+        name = folder_name(path)
         files_path = Serializer::Files::Path.new(
           base_path: account.local_path, folder_name: name
         )
@@ -60,7 +61,7 @@ module Imap::Backup
       return enum_for(:each_value) if !block
 
       glob.each do |path|
-        name = path.relative_path_from(base).to_s[0..-6]
+        name = folder_name(path)
         folder = Account::Folder.new(account.client, name)
         block.call(folder)
       end
@@ -69,6 +70,11 @@ module Imap::Backup
     private
 
     attr_reader :account
+
+    def folder_name(path)
+      local_name = path.relative_path_from(base).to_s[0..-6]
+      Naming.from_local_path(local_name)
+    end
 
     def base
       @base ||= Pathname.new(account.local_path)

--- a/lib/imap/backup/serializer.rb
+++ b/lib/imap/backup/serializer.rb
@@ -22,6 +22,8 @@ module Imap::Backup
       delete
       each_message
       get
+      imap
+      mbox
       messages
       reload
       update

--- a/lib/imap/backup/serializer/delayed_metadata_serializer.rb
+++ b/lib/imap/backup/serializer/delayed_metadata_serializer.rb
@@ -104,11 +104,11 @@ module Imap::Backup
     end
 
     def mbox
-      @mbox ||= Serializer::Mbox.new(files_path: serializer.files_path)
+      serializer.mbox
     end
 
     def imap
-      @imap ||= Serializer::Imap.new(files_path: serializer.files_path)
+      serializer.imap
     end
 
     def tsx

--- a/spec/unit/account/folder_mapper_spec.rb
+++ b/spec/unit/account/folder_mapper_spec.rb
@@ -65,6 +65,14 @@ module Imap::Backup
       end
     end
 
+    context "when the file name contains escaped characters" do
+      let(:path) { "folder_enumerator_path/Notes 10%3a;00.imap" }
+
+      it "decodes them in the folder name" do
+        expect(result[1].name).to eq("Notes 10:00")
+      end
+    end
+
     context "when source_delimiter is supplied" do
       let(:options) { super().merge(source_delimiter: ".") }
       let(:path) { "folder_enumerator_path/src/foo.imap" }

--- a/spec/unit/account/serialized_folders_spec.rb
+++ b/spec/unit/account/serialized_folders_spec.rb
@@ -55,5 +55,16 @@ module Imap::Backup
         expect(enumerator.to_a).to eq([folder])
       end
     end
+
+    context "when a serialized folder name contains escaped characters" do
+      let(:paths) { [Pathname.new("/backups/Notes 10%3a;00.imap")] }
+
+      it "decodes the name when building the folder" do
+        subject.each_value { |_| }
+
+        expect(Account::Folder).
+          to have_received(:new).with(client, "Notes 10:00")
+      end
+    end
   end
 end

--- a/spec/unit/serializer/delayed_metadata_serializer_spec.rb
+++ b/spec/unit/serializer/delayed_metadata_serializer_spec.rb
@@ -5,11 +5,11 @@ module Imap::Backup
   RSpec.describe Serializer::DelayedMetadataSerializer do
     subject(:delayed_serializer) { described_class.new(serializer: serializer) }
 
-    let(:files_path) { "folder_path" }
     let(:serializer) do
       instance_double(
         Serializer,
-        files_path: files_path,
+        imap: imap,
+        mbox: mbox,
         apply_uid_validity: nil,
         reload: nil
       )
@@ -38,8 +38,6 @@ module Imap::Backup
     let(:logger) { instance_double(::Logger, error: nil) }
 
     before do
-      allow(Serializer::Imap).to receive(:new).with(files_path: files_path) { imap }
-      allow(Serializer::Mbox).to receive(:new).with(files_path: files_path) { mbox }
       allow(imap).to receive(:transaction).and_yield
       allow(mbox).to receive(:transaction).and_yield
       allow(Email::Mboxrd::Message).to receive(:new) { mboxrd_message }


### PR DESCRIPTION
  ## Summary

  Fix a backup failure for folders whose names contain a character that is
  escaped on disk (for example `:`).

  ## Problem

  `Serializer::Files` escapes reserved characters when it builds file paths
  for a folder (for example `:` becomes `%3a;`). When the `delay_metadata`
  download strategy is used, `DelayedMetadataSerializer` built its own `Imap`
  and `Mbox` objects directly from the unescaped folder path, bypassing this
  escaping.

  As a result, the two halves of a backup used different files:

  - `apply_uid_validity` wrote the UID validity to the escaped path.
  - `commit` read and wrote the unescaped path.

  The UID validity was therefore not found when saving the metadata, and the
  backup failed with: _"Cannot save metadata without a uid_validity"_

  A second issue affected reading backups: when restoring, migrating, or
  listing local folders, the escaped on-disk name was used as-is instead of
  being decoded. A folder backed up as `foo%3a;bar` was treated as a folder
  literally named `foo%3a;bar`.

  ## Changes

  - `DelayedMetadataSerializer` now uses the serializer's `imap` and `mbox`
    objects, so it reads and writes the same escaped paths as the rest of the
    serializer.
  - Added `imap` and `mbox` delegators to `Serializer`.
  - `Account::SerializedFolders` and `Account::FolderMapper` now decode
    escaped folder names with `Naming.from_local_path` when reading a backup.

  ## Compatibility

  The on-disk format is unchanged. Existing backups are unaffected; the read
  path now decodes names that were already being written escaped.

  ## Tests

  - `DelayedMetadataSerializer` spec: verifies it uses the serializer's
    `imap`/`mbox`.
  - `SerializedFolders` and `FolderMapper` specs: verify escaped on-disk names
    are decoded when read.