### PR TITLE
Fix silent message loss when headers contain raw 8-bit bytes

### DIFF
--- a/lib/imap/backup/email/mboxrd/message.rb
+++ b/lib/imap/backup/email/mboxrd/message.rb
@@ -110,12 +110,39 @@ module Imap::Backup
       end
 
       def best_from
-        return first_from if first_from
-        return parsed.sender if parsed.sender
-        return parsed.envelope_from if parsed.envelope_from
-        return parsed.return_path if parsed.return_path
+        decode_failed = false
 
-        ""
+        [
+          -> { first_from },
+          -> { parsed.sender },
+          -> { parsed.envelope_from },
+          -> { parsed.return_path }
+        ].each do |candidate|
+          value = candidate.call
+          return value if value
+        rescue StandardError
+          # The mail gem raises Encoding::CompatibilityError while DECODING
+          # some headers: Mail::Encodings.value_decode joins decoded
+          # encoded-words with undecoded remainders. Reading the sender can
+          # therefore blow up before this library sees a value. Present in
+          # mail 2.7.1 and still in 2.8.1.
+          decode_failed = true
+        end
+
+        # The raw fallback applies ONLY when decoding raised. A header the mail
+        # gem parsed to nothing still yields nothing, exactly as before.
+        decode_failed ? raw_from.to_s : ""
+      end
+
+      # Last resort: read the address out of the raw bytes, without asking the
+      # mail gem to decode anything. The "From " line is only an mbox
+      # separator; the real header is preserved verbatim in the message body
+      # either way.
+      def raw_from
+        line = supplied_body.b[/^From:.*$/i]
+        return nil if line.nil?
+
+        line[/[^\s<>:,"]+@[^\s<>,"]+/]
       end
 
       def first_from

--- a/lib/imap/backup/email/mboxrd/message.rb
+++ b/lib/imap/backup/email/mboxrd/message.rb
@@ -57,9 +57,24 @@ module Imap::Backup
 
       # @return [String] the message with an initial 'From ADDRESS' line
       def to_serialized
-        from_line = "From #{from}\n"
-        body = mboxrd_body.dup.force_encoding(Encoding::UTF_8)
-        from_line + body
+        # Build the entry from bytes rather than characters.
+        #
+        # `from` is derived from the parsed headers and stays ASCII-8BIT when
+        # the header carries raw 8-bit bytes, e.g. a Latin-1 sender name.
+        # Joining that with a UTF-8 body raises Encoding::CompatibilityError,
+        # and so does "From #{from}\n" on its own, because interpolating into
+        # a UTF-8 literal converts just as concatenation does.
+        #
+        # An mbox file is a byte stream and Mbox#append opens it in binary
+        # mode, so joining in ASCII-8BIT preserves the original bytes exactly
+        # and cannot raise. Messages that are plain ASCII or valid UTF-8
+        # serialize to identical bytes as before.
+        serialized = +"".b
+        serialized << "From ".b
+        serialized << from.to_s.b
+        serialized << "\n".b
+        serialized << mboxrd_body.b
+        serialized
       end
 
       # @return [Date, nil] the date of the message

--- a/spec/unit/email/mboxrd/message_spec.rb
+++ b/spec/unit/email/mboxrd/message_spec.rb
@@ -189,6 +189,29 @@ module Imap::Backup
         end
       end
 
+      context "when the mail gem cannot decode the sender" do
+        # An RFC 2047 encoded-word display name combined with a raw 8-bit
+        # address makes Mail::Encodings.value_decode raise while parsing,
+        # before this library can use the value. Reproducible on mail 2.7.1
+        # and still on 2.8.1.
+        let(:message_body) do
+          "Return-Path: <\"gru\xDFe\"@example.com>\r\n" \
+          "From: =?iso-8859-1?Q?Gr=FC=DFe?= <gru\xDFe@example.com>\r\n" \
+          "To: FirstName LastName <you@example.com>\r\n" \
+          "Subject: Re: no subject\r\n" \
+          "\r\n" \
+          "Text \xDF\r\n".b
+        end
+
+        it "does not fail" do
+          expect { subject.to_serialized }.to_not raise_error
+        end
+
+        it "falls back to the address from the raw header" do
+          expect(subject.to_serialized).to include("gru\xDFe@example.com".b)
+        end
+      end
+
       context "when date is missing" do
         let(:message_body) { msg_no_date }
 

--- a/spec/unit/email/mboxrd/message_spec.rb
+++ b/spec/unit/email/mboxrd/message_spec.rb
@@ -157,6 +157,38 @@ module Imap::Backup
         expect(subject.to_serialized).to include("\n>>>From quoted")
       end
 
+      context "when the sender address and the body both contain raw 8-bit bytes" do
+        # Latin-1 bytes in the address itself, as still sent by older clients.
+        # The From line keeps the header's ASCII-8BIT encoding while the body
+        # was forced to UTF-8, so joining the two raised
+        # Encoding::CompatibilityError.
+        #
+        # Both sides need non-ASCII bytes to trigger it: Ruby joins ASCII-8BIT
+        # with UTF-8 happily as long as one side is pure ASCII. The bytes must
+        # also be in the address, not just a display name, because the display
+        # name is discarded during parsing.
+        let(:message_body) do
+          "Return-Path: <\"test_us\xE9r\"@example.com>\r\n" \
+          "From: \"Test Sender\" <test_us\xE9r@example.com>\r\n" \
+          "To: FirstName LastName <you@example.com>\r\n" \
+          "Subject: Re: no subject\r\n" \
+          "\r\n" \
+          "Text with a Latin-1 byte: \xE1\r\n".b
+        end
+
+        it "does not fail" do
+          expect { subject.to_serialized }.to_not raise_error
+        end
+
+        it "preserves the original bytes of the sender" do
+          expect(subject.to_serialized).to include("test_us\xE9r".b)
+        end
+
+        it "preserves the original bytes of the body" do
+          expect(subject.to_serialized).to include("Latin-1 byte: \xE1".b)
+        end
+      end
+
       context "when date is missing" do
         let(:message_body) { msg_no_date }
 


### PR DESCRIPTION
# Fix silent message loss when headers contain raw 8-bit bytes

Two encoding faults cause messages to be skipped without the run failing. Both
raise inside `Serializer::Appender#rollback_on_error`, which logs the exception
and rolls the append back, so the message is never written and the backup still
exits successfully. Both reproduce on `main` (17.0.0.rc0).

## 1. Mismatched encodings when building the entry

`Email::Mboxrd::Message#to_serialized` forces the body to UTF-8 but leaves the
`From ` line with the encoding of the parsed headers:

```ruby
from_line = "From #{from}\n"
body = mboxrd_body.dup.force_encoding(Encoding::UTF_8)
from_line + body
```

A sender address containing raw 8-bit bytes keeps that line `ASCII-8BIT`, and
the join raises `Encoding::CompatibilityError`.

`"From #{from}\n"` is unsafe in the same way — the literal is UTF-8 source, so
interpolating an 8-bit header raises just as concatenation does, reporting its
operands in the opposite order. Fixing only the outer join leaves messages
failing.

Triggering it needs non-ASCII bytes in **both** the sender and the body, since
Ruby joins `ASCII-8BIT` with UTF-8 when either side is pure ASCII; and the bytes
must be in the **address**, as a display name is discarded during parsing.

**Fix:** build the entry from bytes. An mbox file is a byte stream and
`Mbox#append` opens it in binary mode, so joining in `ASCII-8BIT` preserves the
bytes exactly and cannot raise. `serialized.bytesize` is unaffected, and ASCII
or valid UTF-8 messages serialize identically to before.

## 2. The `mail` gem raises while parsing the sender

`Mail::Encodings.value_decode` raises `Encoding::CompatibilityError` for some
`From` headers — an RFC 2047 encoded-word display name combined with a raw
8-bit address is enough:

```
From: =?iso-8859-1?Q?Gr=FC=DFe?= <gru\xDFe@example.com>
```

This happens while parsing, so the fix above cannot help. It is present in the
pinned `mail` 2.7.1 and in 2.8.1, so upgrading the dependency does not address
it.

**Fix:** treat each route to the sender as fallible and, only when decoding
raised, read the address from the raw header bytes. Headers the gem parses to
nothing still yield nothing, so existing behaviour is unchanged.

## Verification

Each fix has a regression spec that fails before it and passes after, using
synthetic fixtures. `spec/unit`: 1021 examples, 0 failures. `rubocop lib spec`:
no offenses.

## Related, not addressed here

`rollback_on_error` catches `StandardError`, logs it and rolls back, so a
message can be dropped while the run exits 0 — a clean exit does not imply a
complete backup. Changing that reaches beyond these two faults, but it is what
turns them into silent data loss.

## Provenance

Written by an LLM (Claude) and verified against the test suite and the failing
cases. Please treat it as a starting point: change, split, rewrite or close it
as best serves the project. If the diagnosis is useful but the implementation
is not, the reproduction cases in the specs should stand on their own.
